### PR TITLE
cleanup(deps): Update Images & Deps

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,6 +19,7 @@ module.exports = {
     ],
   },
   plugins: [
+    `gatsby-plugin-image`,
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-source-filesystem`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "babel-plugin-styled-components": "^2.1.4",
         "express-validator": "^7.0.1",
         "gatsby": "^5.12.4",
-        "gatsby-image": "^3.11.0",
         "gatsby-plugin-image": "^3.12.0",
         "gatsby-plugin-manifest": "^5.12.0",
         "gatsby-plugin-netlify": "^5.1.1",
@@ -12080,20 +12079,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/gatsby-image": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-3.11.0.tgz",
-      "integrity": "sha512-vRMhGLrgyQRH2RYs8leyZ1UyWYIew+NOZEsKur1w6gnWDf0U9UVmYFa9OIE1Vedlo1W+on3AuZ3/KwM+cI69VQ==",
-      "deprecated": "gatsby-image is now gatsby-plugin-image: https://npm.im/gatsby-plugin-image. This package will no longer receive updates.",
-      "dependencies": {
-        "@babel/runtime": "^7.14.6",
-        "object-fit-images": "^3.2.4",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
     "node_modules/gatsby-legacy-polyfills": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-3.12.0.tgz",
@@ -17950,11 +17935,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/object-fit-images": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/object-fit-images/-/object-fit-images-3.2.4.tgz",
-      "integrity": "sha512-G+7LzpYfTfqUyrZlfrou/PLLLAPNC52FTy5y1CBywX+1/FkxIloOyQXBmZ3Zxa2AWO+lMF0JTuvqbr7G5e5CWg=="
     },
     "node_modules/object-inspect": {
       "version": "1.12.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "babel-plugin-styled-components": "^2.1.4",
     "express-validator": "^7.0.1",
     "gatsby": "^5.12.4",
-    "gatsby-image": "^3.11.0",
     "gatsby-plugin-image": "^3.12.0",
     "gatsby-plugin-manifest": "^5.12.0",
     "gatsby-plugin-netlify": "^5.1.1",


### PR DESCRIPTION
Get rid of older `gatsby-image` & add `gatsby-plugin-image` to gatsby config.